### PR TITLE
Update MCP command to use scoped package name

### DIFF
--- a/packages/dataqueue/src/install-mcp-command.test.ts
+++ b/packages/dataqueue/src/install-mcp-command.test.ts
@@ -22,7 +22,7 @@ describe('upsertMcpConfig', () => {
     upsertMcpConfig(
       '/path/mcp.json',
       'dataqueue',
-      { command: 'npx', args: ['dataqueue-cli', 'mcp'] },
+      { command: 'npx', args: ['@nicnocquee/dataqueue', 'mcp'] },
       deps,
     );
 
@@ -30,7 +30,7 @@ describe('upsertMcpConfig', () => {
     const written = JSON.parse(deps.writeFileSync.mock.calls[0][1] as string);
     expect(written.mcpServers.dataqueue).toEqual({
       command: 'npx',
-      args: ['dataqueue-cli', 'mcp'],
+      args: ['@nicnocquee/dataqueue', 'mcp'],
     });
   });
 
@@ -49,7 +49,7 @@ describe('upsertMcpConfig', () => {
     upsertMcpConfig(
       '/path/mcp.json',
       'dataqueue',
-      { command: 'npx', args: ['dataqueue-cli', 'mcp'] },
+      { command: 'npx', args: ['@nicnocquee/dataqueue', 'mcp'] },
       deps,
     );
 
@@ -58,7 +58,7 @@ describe('upsertMcpConfig', () => {
     expect(written.mcpServers.other).toEqual({ command: 'other' });
     expect(written.mcpServers.dataqueue).toEqual({
       command: 'npx',
-      args: ['dataqueue-cli', 'mcp'],
+      args: ['@nicnocquee/dataqueue', 'mcp'],
     });
   });
 
@@ -133,7 +133,10 @@ describe('runInstallMcp', () => {
         .calls[0][1] as string,
     );
     expect(written.mcpServers.dataqueue.command).toBe('npx');
-    expect(written.mcpServers.dataqueue.args).toEqual(['dataqueue-cli', 'mcp']);
+    expect(written.mcpServers.dataqueue.args).toEqual([
+      '@nicnocquee/dataqueue',
+      'mcp',
+    ]);
   });
 
   it('installs MCP config for Claude Code (option 2)', async () => {
@@ -210,7 +213,7 @@ describe('runInstallMcp', () => {
 
     // Assert
     expect(deps.log).toHaveBeenCalledWith(
-      expect.stringContaining('npx dataqueue-cli mcp'),
+      expect.stringContaining('npx @nicnocquee/dataqueue mcp'),
     );
   });
 });

--- a/packages/dataqueue/src/install-mcp-command.ts
+++ b/packages/dataqueue/src/install-mcp-command.ts
@@ -70,7 +70,7 @@ export function upsertMcpConfig(
 
 const MCP_SERVER_CONFIG = {
   command: 'npx',
-  args: ['dataqueue-cli', 'mcp'],
+  args: ['@nicnocquee/dataqueue', 'mcp'],
 };
 
 const MCP_CLIENTS: Record<string, McpClientConfig> = {
@@ -177,7 +177,7 @@ export async function runInstallMcp({
       existsSync,
       log,
     });
-    log('\nDone! The MCP server will run via: npx dataqueue-cli mcp');
+    log('\nDone! The MCP server will run via: npx @nicnocquee/dataqueue mcp');
   } catch (err) {
     error('Failed to install MCP config:', err);
     exit(1);


### PR DESCRIPTION
## Summary

Updates MCP install and config to use the scoped package name `@nicnocquee/dataqueue` instead of `dataqueue-cli`, so the MCP server command matches the published package and works correctly when users run the install flow.

## Important changes

- Default MCP server config now uses `npx @nicnocquee/dataqueue mcp` instead of `npx dataqueue-cli mcp`
- Success log message after MCP install shows the new command
- Existing MCP configs written by this flow will use the scoped package name

## Other changes

- Test expectations and fixtures updated to assert the new command in `install-mcp-command.test.ts`

## How to test

1. From the repo root, run the MCP install (e.g. `npx @nicnocquee/dataqueue mcp install` or the equivalent entry point).
2. Confirm the generated MCP config (e.g. in `~/.cursor/mcp.json` or the path you use) has `args: ['@nicnocquee/dataqueue', 'mcp']` for the dataqueue server.
3. Run `pnpm test` in `packages/dataqueue` and confirm all tests pass.